### PR TITLE
Fix shortcut commands failing with unexpected keyword argument

### DIFF
--- a/src/it2/commands/shortcuts.py
+++ b/src/it2/commands/shortcuts.py
@@ -27,9 +27,7 @@ def register_shortcuts(cli: click.Group) -> None:
         """Shortcut for 'it2 session run'."""
         from . import session as session_module
 
-        ctx.invoke(
-            session_module.run, command=command, session=session, all_sessions=all_sessions
-        )
+        ctx.invoke(session_module.run, command=command, session=session, all_sessions=all_sessions)
 
     @cli.command("split")
     @click.option("--vertical", "-v", is_flag=True, help="Split vertically")

--- a/src/it2/commands/shortcuts.py
+++ b/src/it2/commands/shortcuts.py
@@ -10,25 +10,25 @@ def register_shortcuts(cli: click.Group) -> None:
     @cli.command("send")
     @click.argument("text")
     @click.option("--session", "-s", help="Target session ID (default: active)")
-    @click.option("--all", "-a", is_flag=True, help="Send to all sessions")
+    @click.option("--all", "-a", "all_sessions", is_flag=True, help="Send to all sessions")
     @click.pass_context
-    def send_shortcut(ctx: click.Context, text: str, session_id: str, all_sessions: bool) -> None:
+    def send_shortcut(ctx: click.Context, text: str, session: str, all_sessions: bool) -> None:
         """Shortcut for 'it2 session send'."""
         from . import session as session_module
 
-        ctx.invoke(session_module.send, text=text, session=session_id, all_sessions=all_sessions)
+        ctx.invoke(session_module.send, text=text, session=session, all_sessions=all_sessions)
 
     @cli.command("run")
     @click.argument("command")
     @click.option("--session", "-s", help="Target session ID (default: active)")
-    @click.option("--all", "-a", is_flag=True, help="Run in all sessions")
+    @click.option("--all", "-a", "all_sessions", is_flag=True, help="Run in all sessions")
     @click.pass_context
-    def run_shortcut(ctx: click.Context, command: str, session_id: str, all_sessions: bool) -> None:
+    def run_shortcut(ctx: click.Context, command: str, session: str, all_sessions: bool) -> None:
         """Shortcut for 'it2 session run'."""
         from . import session as session_module
 
         ctx.invoke(
-            session_module.run, command=command, session=session_id, all_sessions=all_sessions
+            session_module.run, command=command, session=session, all_sessions=all_sessions
         )
 
     @cli.command("split")
@@ -36,30 +36,30 @@ def register_shortcuts(cli: click.Group) -> None:
     @click.option("--session", "-s", help="Target session ID (default: active)")
     @click.option("--profile", "-p", help="Profile to use for new pane")
     @click.pass_context
-    def split_shortcut(ctx: click.Context, vertical: bool, session_id: str, profile: str) -> None:
+    def split_shortcut(ctx: click.Context, vertical: bool, session: str, profile: str) -> None:
         """Shortcut for 'it2 session split'."""
         from . import session as session_module
 
-        ctx.invoke(session_module.split, vertical=vertical, session=session_id, profile=profile)
+        ctx.invoke(session_module.split, vertical=vertical, session=session, profile=profile)
 
     @cli.command("vsplit")
     @click.option("--session", "-s", help="Target session ID (default: active)")
     @click.option("--profile", "-p", help="Profile to use for new pane")
     @click.pass_context
-    def vsplit_shortcut(ctx: click.Context, session_id: str, profile: str) -> None:
+    def vsplit_shortcut(ctx: click.Context, session: str, profile: str) -> None:
         """Shortcut for 'it2 session split --vertical'."""
         from . import session as session_module
 
-        ctx.invoke(session_module.split, vertical=True, session=session_id, profile=profile)
+        ctx.invoke(session_module.split, vertical=True, session=session, profile=profile)
 
     @cli.command("clear")
     @click.option("--session", "-s", help="Target session ID (default: active)")
     @click.pass_context
-    def clear_shortcut(ctx: click.Context, session_id: str) -> None:
+    def clear_shortcut(ctx: click.Context, session: str) -> None:
         """Shortcut for 'it2 session clear'."""
         from . import session as session_module
 
-        ctx.invoke(session_module.clear, session=session_id)
+        ctx.invoke(session_module.clear, session=session)
 
     @cli.command("ls")
     @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
@@ -87,8 +87,8 @@ def register_shortcuts(cli: click.Group) -> None:
     @click.option("--window", "-w", help="Window ID to create tab in (default: current)")
     @click.option("--command", "-c", help="Command to run in new tab")
     @click.pass_context
-    def newtab_shortcut(ctx: click.Context, profile: str, window_id: str, command: str) -> None:
+    def newtab_shortcut(ctx: click.Context, profile: str, window: str, command: str) -> None:
         """Shortcut for 'it2 tab new'."""
         from . import tab as tab_module
 
-        ctx.invoke(tab_module.new, profile=profile, window=window_id, command=command)
+        ctx.invoke(tab_module.new, profile=profile, window=window, command=command)

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,6 +1,7 @@
 """Tests for shortcut commands — verify shortcuts invoke the same logic as full commands."""
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -66,18 +67,27 @@ def mock_app(mock_session):
     app = MagicMock()
 
     tab = MagicMock()
+    tab.tab_id = "test-tab-456"
     tab.sessions = [mock_session]
     tab.current_session = mock_session
 
     window = MagicMock()
+    window.window_id = "test-window-789"
     window.tabs = [tab]
     window.current_tab = tab
+    window.async_create_tab = AsyncMock(return_value=tab)
 
     app.windows = [window]
     app.current_terminal_window = window
     app.get_session_by_id = MagicMock(return_value=mock_session)
+    app.async_create_window = AsyncMock(return_value=window)
 
     return app
+
+
+# ---------------------------------------------------------------------------
+# send shortcut
+# ---------------------------------------------------------------------------
 
 
 @patch("iterm2.Connection.async_create")
@@ -115,6 +125,84 @@ def test_send_shortcut(
 @patch("iterm2.run_until_complete")
 @patch("os.environ.get")
 @patch("it2.core.connection._connection_manager")
+def test_send_shortcut_with_all(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+):
+    """Test 'it2 send --all' sends to all sessions."""
+    session1 = MagicMock()
+    session1.async_send_text = AsyncMock()
+    session2 = MagicMock()
+    session2.async_send_text = AsyncMock()
+
+    tab1 = MagicMock(sessions=[session1])
+    tab2 = MagicMock(sessions=[session2])
+    window = MagicMock(tabs=[tab1, tab2])
+    mock_app.windows = [window]
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["send", "Hello!", "--all"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    assert "Sent text to 2 sessions" in result.output
+    session1.async_send_text.assert_called_once_with("Hello!")
+    session2.async_send_text.assert_called_once_with("Hello!")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_send_shortcut_with_session(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 send --session <id>' targets a specific session."""
+    mock_app.get_session_by_id = MagicMock(return_value=mock_session)
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["send", "Hello!", "--session", "test-session-123"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_send_text.assert_called_once_with("Hello!")
+
+
+# ---------------------------------------------------------------------------
+# run shortcut
+# ---------------------------------------------------------------------------
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
 def test_run_shortcut(
     mock_conn_mgr,
     mock_env_get,
@@ -145,6 +233,84 @@ def test_run_shortcut(
 @patch("iterm2.run_until_complete")
 @patch("os.environ.get")
 @patch("it2.core.connection._connection_manager")
+def test_run_shortcut_with_all(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+):
+    """Test 'it2 run --all' runs in all sessions."""
+    session1 = MagicMock()
+    session1.async_send_text = AsyncMock()
+    session2 = MagicMock()
+    session2.async_send_text = AsyncMock()
+
+    tab1 = MagicMock(sessions=[session1])
+    tab2 = MagicMock(sessions=[session2])
+    window = MagicMock(tabs=[tab1, tab2])
+    mock_app.windows = [window]
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["run", "echo hi", "--all"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    assert "Executed command in 2 sessions" in result.output
+    session1.async_send_text.assert_called_once_with("echo hi\r")
+    session2.async_send_text.assert_called_once_with("echo hi\r")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_run_shortcut_with_session(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 run --session <id>' targets a specific session."""
+    mock_app.get_session_by_id = MagicMock(return_value=mock_session)
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["run", "ls", "--session", "test-session-123"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_send_text.assert_called_once_with("ls\r")
+
+
+# ---------------------------------------------------------------------------
+# clear shortcut
+# ---------------------------------------------------------------------------
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
 def test_clear_shortcut(
     mock_conn_mgr,
     mock_env_get,
@@ -168,6 +334,43 @@ def test_clear_shortcut(
     result = runner.invoke(cli, ["clear"])
     assert result.exit_code == 0, f"Failed with: {result.output}"
     mock_session.async_send_text.assert_called_once_with("\x0c")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_clear_shortcut_with_session(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 clear --session <id>' targets a specific session."""
+    mock_app.get_session_by_id = MagicMock(return_value=mock_session)
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["clear", "--session", "test-session-123"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_send_text.assert_called_once_with("\x0c")
+
+
+# ---------------------------------------------------------------------------
+# split shortcut
+# ---------------------------------------------------------------------------
 
 
 @patch("iterm2.Connection.async_create")
@@ -207,6 +410,109 @@ def test_split_shortcut(
 @patch("iterm2.run_until_complete")
 @patch("os.environ.get")
 @patch("it2.core.connection._connection_manager")
+def test_split_shortcut_vertical(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 split --vertical' splits vertically."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    mock_session.async_split_pane.return_value = MagicMock(session_id="new-session-456")
+
+    result = runner.invoke(cli, ["split", "--vertical"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_split_pane.assert_called_once_with(vertical=True, profile=None)
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_split_shortcut_with_profile(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 split --profile <name>' uses specified profile."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    mock_session.async_split_pane.return_value = MagicMock(session_id="new-session-456")
+
+    result = runner.invoke(cli, ["split", "--profile", "Development"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_split_pane.assert_called_once_with(vertical=False, profile="Development")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_split_shortcut_with_session(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 split --session <id>' targets a specific session."""
+    mock_app.get_session_by_id = MagicMock(return_value=mock_session)
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    mock_session.async_split_pane.return_value = MagicMock(session_id="new-session-456")
+
+    result = runner.invoke(cli, ["split", "--session", "test-session-123"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_split_pane.assert_called_once_with(vertical=False, profile=None)
+
+
+# ---------------------------------------------------------------------------
+# vsplit shortcut
+# ---------------------------------------------------------------------------
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
 def test_vsplit_shortcut(
     mock_conn_mgr,
     mock_env_get,
@@ -232,3 +538,282 @@ def test_vsplit_shortcut(
     result = runner.invoke(cli, ["vsplit"])
     assert result.exit_code == 0, f"Failed with: {result.output}"
     mock_session.async_split_pane.assert_called_once_with(vertical=True, profile=None)
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_vsplit_shortcut_with_profile(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 vsplit --profile <name>' uses specified profile."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    mock_session.async_split_pane.return_value = MagicMock(session_id="new-session-456")
+
+    result = runner.invoke(cli, ["vsplit", "--profile", "Development"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_split_pane.assert_called_once_with(vertical=True, profile="Development")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_vsplit_shortcut_with_session(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 vsplit --session <id>' targets a specific session."""
+    mock_app.get_session_by_id = MagicMock(return_value=mock_session)
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    mock_session.async_split_pane.return_value = MagicMock(session_id="new-session-456")
+
+    result = runner.invoke(cli, ["vsplit", "--session", "test-session-123"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_split_pane.assert_called_once_with(vertical=True, profile=None)
+
+
+# ---------------------------------------------------------------------------
+# ls shortcut
+# ---------------------------------------------------------------------------
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_ls_shortcut_json(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 ls --json' lists sessions as JSON."""
+    mock_session.async_get_variable = AsyncMock(
+        side_effect=lambda var: {
+            "session.name": "Test Session",
+            "session.title": "Test Title",
+            "session.tty": "/dev/ttys001",
+            "session.tmux": "no",
+        }.get(var)
+    )
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["ls", "--json"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    data = json.loads(result.output)
+    assert len(data) == 1
+    assert data[0]["id"] == "test-session-123"
+
+
+# ---------------------------------------------------------------------------
+# new shortcut (window)
+# ---------------------------------------------------------------------------
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_new_shortcut(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+):
+    """Test 'it2 new' shortcut creates a new window."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["new"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_app.async_create_window.assert_called_once_with(profile=None)
+    assert "Created new window" in result.output
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_new_shortcut_with_profile_and_command(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 new --profile <name> --command <cmd>' passes options through."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["new", "--profile", "Development", "--command", "htop"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_app.async_create_window.assert_called_once_with(profile="Development")
+    mock_session.async_send_text.assert_called_once_with("htop\r")
+
+
+# ---------------------------------------------------------------------------
+# newtab shortcut
+# ---------------------------------------------------------------------------
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_newtab_shortcut(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+):
+    """Test 'it2 newtab' shortcut creates a new tab."""
+    window = mock_app.current_terminal_window
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["newtab"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    window.async_create_tab.assert_called_once_with(profile=None)
+    assert "Created new tab" in result.output
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_newtab_shortcut_with_profile_and_command(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 newtab --profile <name> --command <cmd>' passes options through."""
+    window = mock_app.current_terminal_window
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["newtab", "--profile", "Development", "--command", "htop"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    window.async_create_tab.assert_called_once_with(profile="Development")
+    mock_session.async_send_text.assert_called_once_with("htop\r")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_newtab_shortcut_with_window(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+):
+    """Test 'it2 newtab --window <id>' creates tab in specific window."""
+    window = mock_app.current_terminal_window
+
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["newtab", "--window", "test-window-789"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    window.async_create_tab.assert_called_once_with(profile=None)

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,0 +1,234 @@
+"""Tests for shortcut commands — verify shortcuts invoke the same logic as full commands."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from it2.cli import cli
+
+
+def setup_iterm2_mocks(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    mock_app,
+):
+    """Helper to set up common mocks for tests."""
+
+    def env_side_effect(key, default=None):
+        if key == "ITERM2_COOKIE":
+            return "test-cookie"
+        if key == "TERM":
+            return "dumb"
+        return default if default is not None else None
+
+    mock_env_get.side_effect = env_side_effect
+
+    mock_connection = MagicMock()
+    mock_async_create.return_value = mock_connection
+    mock_async_get_app.return_value = mock_app
+
+    mock_conn_mgr.connect = AsyncMock()
+    mock_conn_mgr.get_app = AsyncMock(return_value=mock_app)
+    mock_conn_mgr.close = AsyncMock()
+
+    def run_coro(coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    mock_run_until_complete.side_effect = run_coro
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_session():
+    session = MagicMock()
+    session.session_id = "test-session-123"
+    session.async_send_text = AsyncMock()
+    session.async_split_pane = AsyncMock()
+    session.grid_size = MagicMock(width=80, height=24)
+    return session
+
+
+@pytest.fixture
+def mock_app(mock_session):
+    app = MagicMock()
+
+    tab = MagicMock()
+    tab.sessions = [mock_session]
+    tab.current_session = mock_session
+
+    window = MagicMock()
+    window.tabs = [tab]
+    window.current_tab = tab
+
+    app.windows = [window]
+    app.current_terminal_window = window
+    app.get_session_by_id = MagicMock(return_value=mock_session)
+
+    return app
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_send_shortcut(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 send' shortcut invokes session send."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["send", "Hello, World!"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_send_text.assert_called_once_with("Hello, World!")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_run_shortcut(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 run' shortcut invokes session run."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["run", "ls -la"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_send_text.assert_called_once_with("ls -la\r")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_clear_shortcut(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 clear' shortcut invokes session clear."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    result = runner.invoke(cli, ["clear"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_send_text.assert_called_once_with("\x0c")
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_split_shortcut(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 split' shortcut invokes session split."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    mock_session.async_split_pane.return_value = MagicMock(session_id="new-session-456")
+
+    result = runner.invoke(cli, ["split"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_split_pane.assert_called_once_with(vertical=False, profile=None)
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
+def test_vsplit_shortcut(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test 'it2 vsplit' shortcut invokes session split --vertical."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+
+    mock_session.async_split_pane.return_value = MagicMock(session_id="new-session-456")
+
+    result = runner.invoke(cli, ["vsplit"])
+    assert result.exit_code == 0, f"Failed with: {result.output}"
+    mock_session.async_split_pane.assert_called_once_with(vertical=True, profile=None)


### PR DESCRIPTION
## Summary

- Fix `TypeError` when using shortcut commands (`it2 send`, `it2 run`, `it2 split`, `it2 vsplit`, `it2 clear`, `it2 newtab`) caused by Click option names not matching function parameter names
- Add comprehensive tests for all shortcut commands (21 tests), covering both basic invocation and option-passing paths (`--session`, `--all`, `--profile`, `--vertical`, `--window`, `--command`)

## Root Cause

Click derives function parameter names from option names (e.g. `--session` → `session`), but the shortcut functions used different names (e.g. `session_id`). This caused Click to raise:

```
TypeError: send_shortcut() got an unexpected keyword argument 'session'
```

The same mismatch affected `--all` (expected `all`, got `all_sessions`) and `--window` (expected `window`, got `window_id`).

## Changes

**`src/it2/commands/shortcuts.py`**:
- Rename `session_id` → `session` in `send`, `run`, `split`, `vsplit`, `clear`
- Rename `window_id` → `window` in `newtab`
- Add explicit `"all_sessions"` parameter name to `--all` options in `send`, `run`

**`tests/test_shortcuts.py`** (new file):
- 21 tests covering all 8 shortcuts with their option variants
- Tests verify that shortcut commands reach the underlying iTerm2 API with correct arguments

## Test plan

- [x] All 21 new shortcut tests pass
- [x] Full test suite passes (119 passed, 9 skipped)
- [x] Manual verification: `it2 send`, `it2 run`, `it2 clear`, `it2 split`, `it2 vsplit`, `it2 ls`, `it2 newtab` all exit 0

Fixes #1