### PR TITLE
Configure Renovate: bump strategy, group dev deps, require approval for Python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
-  ]
+  ],
+  "rangeStrategy": "bump"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,25 @@
   "extends": [
     "config:best-practices"
   ],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["tool.uv.dev-dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev dependencies"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.optional-dependencies"],
+      "matchJsonata": ["managerData.depGroup = 'dev'"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev dependencies"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["python"],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Set `rangeStrategy` to `"bump"` so dependency updates bump the lower bound of semver ranges
- Group minor/patch updates for dev dependencies (`tool.uv.dev-dependencies` and `project.optional-dependencies[dev]`) into a single PR
- Require dependency dashboard approval for Python version updates

## Test plan
- [ ] Verify `renovate.json` is valid JSON
- [ ] Confirm Renovate dry-run picks up the new settings