### PR TITLE
fix: pin core-metadata-version to 2.3 for twine compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ addopts = "-v"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/it2"]
+core-metadata-version = "2.3"  # twine 6.x does not fully support metadata 2.4 (license-file validation fails)
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
## Summary
- `[tool.hatch.build.targets.wheel]` に `core-metadata-version = "2.3"` を追加

## Background
hatchling を unpin した (#8) ことで、最新の hatchling (>= 1.27.0) がデフォルトで metadata 2.4 を生成するようになった。
metadata 2.4 には `License-File` フィールドが含まれるが、twine 6.x の `check` コマンドがこれを正しく検証できず CI が失敗する。

metadata version を 2.3 に固定することで、hatchling を unpin したまま twine との互換性を維持する。
twine/packaging が metadata 2.4 を完全サポートしたらこの設定は外せる。

## Related
- #8 (hatchling unpin)
- #22 (CI failure)
- https://github.com/pypa/twine/issues/1216