### PR TITLE
fix: also pin core-metadata-version for sdist target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ core-metadata-version = "2.3"  # twine 6.x does not fully support metadata 2.4 (
 include = [
     "/src",
 ]
+core-metadata-version = "2.3"  # twine 6.x does not fully support metadata 2.4 (license-file validation fails)
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
## Summary
- Add `core-metadata-version = "2.3"` to `[tool.hatch.build.targets.sdist]`

## Background
#28 only set `core-metadata-version = "2.3"` on the wheel target, but the sdist (tar.gz) also generates metadata 2.4 by default, causing `twine check` to fail:

- wheel: PASSED
- sdist: ERROR (`unrecognized or malformed field 'license-file'`)

## Related
- #28
- #22 (CI failure)