### PR TITLE
Add E2E test script and documentation

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# E2E test script for it2 CLI
+#
+# Runs side-effect commands against a live iTerm2 instance to verify
+# that all CLI commands work correctly. Requires iTerm2 to be running
+# with its Python API enabled.
+#
+# Usage:
+#   ./scripts/e2e-test.sh                  # use 'it2' from PATH
+#   ./scripts/e2e-test.sh /path/to/it2     # use specific binary
+#
+# The script creates a temporary window, exercises all commands inside it,
+# and cleans up after itself. The only external side effect is that iTerm2
+# may show a native "Close Window?" dialog when closing a window that has
+# active processes — press OK to continue.
+
+set -euo pipefail
+
+IT2="${1:-it2}"
+PASS=0
+FAIL=0
+FAILURES=""
+
+run_test() {
+  local name="$1"
+  shift
+  local output
+  if output=$("$@" 2>&1); then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name"
+    echo "    output: $output"
+    FAIL=$((FAIL + 1))
+    FAILURES="$FAILURES\n  - $name"
+  fi
+}
+
+echo "=========================================="
+echo "it2 E2E Tests"
+echo "Binary: $IT2"
+echo "$($IT2 --version 2>&1)"
+echo "=========================================="
+
+# ------------------------------------------------------------------
+# App commands (read-only + activate)
+# ------------------------------------------------------------------
+echo ""
+echo "[App]"
+run_test "app activate" "$IT2" app activate
+run_test "app version" "$IT2" app version
+run_test "app theme (get)" "$IT2" app theme
+run_test "app get-focus" "$IT2" app get-focus
+
+# ------------------------------------------------------------------
+# Create an isolated test window for the remaining tests
+# ------------------------------------------------------------------
+echo ""
+echo "[Setup] Creating test window..."
+WIN_OUTPUT=$("$IT2" window new 2>&1)
+echo "  $WIN_OUTPUT"
+sleep 0.5
+
+NEW_WIN=$("$IT2" window list --json 2>&1 | python3 -c "
+import sys, json
+wins = json.load(sys.stdin)
+print(wins[-1]['id'])
+")
+echo "  Window ID: ${NEW_WIN:0:40}..."
+
+# ------------------------------------------------------------------
+# Window commands (side effects)
+# ------------------------------------------------------------------
+echo ""
+echo "[Window]"
+run_test "window list" "$IT2" window list
+run_test "window list --json" "$IT2" window list --json
+run_test "window move" "$IT2" window move 200 200 "$NEW_WIN"
+run_test "window resize" "$IT2" window resize 900 600 "$NEW_WIN"
+run_test "window fullscreen on" "$IT2" window fullscreen toggle "$NEW_WIN"
+sleep 0.5
+run_test "window fullscreen off" "$IT2" window fullscreen toggle "$NEW_WIN"
+sleep 0.5
+
+# ------------------------------------------------------------------
+# Tab commands (side effects)
+# ------------------------------------------------------------------
+echo ""
+echo "[Tab]"
+run_test "tab list" "$IT2" tab list
+run_test "tab list --json" "$IT2" tab list --json
+run_test "tab new" "$IT2" tab new --window "$NEW_WIN"
+sleep 0.3
+run_test "tab next" "$IT2" tab next
+sleep 0.2
+run_test "tab prev" "$IT2" tab prev
+sleep 0.2
+run_test "tab goto 0" "$IT2" tab goto 0
+sleep 0.2
+
+# ------------------------------------------------------------------
+# Session commands (side effects)
+# ------------------------------------------------------------------
+echo ""
+echo "[Session]"
+run_test "session list" "$IT2" session list
+run_test "session list --json" "$IT2" session list --json
+run_test "session split (horizontal)" "$IT2" session split
+sleep 0.3
+run_test "session split --vertical" "$IT2" session split --vertical
+sleep 0.3
+
+# Pick a session in the test window
+SESSION_ID=$("$IT2" session list --json 2>&1 | python3 -c "
+import sys, json
+sessions = json.load(sys.stdin)
+print(sessions[-1]['id'])
+")
+echo "  Target session: ${SESSION_ID:0:20}..."
+
+run_test "session set-name" "$IT2" session set-name "e2e-test" --session "$SESSION_ID"
+run_test "session send" "$IT2" session send "echo hello" --session "$SESSION_ID"
+run_test "session run" "$IT2" session run "echo test" --session "$SESSION_ID"
+sleep 0.3
+run_test "session read" "$IT2" session read --session "$SESSION_ID"
+run_test "session get-var" "$IT2" session get-var columns --session "$SESSION_ID"
+run_test "session clear" "$IT2" session clear --session "$SESSION_ID"
+
+# ------------------------------------------------------------------
+# Profile commands
+# ------------------------------------------------------------------
+echo ""
+echo "[Profile]"
+run_test "profile list" "$IT2" profile list
+run_test "profile show Default" "$IT2" profile show Default
+run_test "profile apply" "$IT2" profile apply Default --session "$SESSION_ID"
+
+# ------------------------------------------------------------------
+# Broadcast commands
+# ------------------------------------------------------------------
+echo ""
+echo "[Broadcast]"
+run_test "broadcast on" "$IT2" app broadcast on
+run_test "broadcast off" "$IT2" app broadcast off
+
+# ------------------------------------------------------------------
+# Shortcuts
+# ------------------------------------------------------------------
+echo ""
+echo "[Shortcuts]"
+run_test "ls" "$IT2" ls
+run_test "ls --json" "$IT2" ls --json
+
+# ------------------------------------------------------------------
+# Config commands (no iTerm2 connection needed)
+# ------------------------------------------------------------------
+echo ""
+echo "[Config]"
+run_test "config-path" "$IT2" config-path
+run_test "config-reload" "$IT2" config-reload
+
+# ------------------------------------------------------------------
+# Cleanup: close the extra tab, then the test window
+# ------------------------------------------------------------------
+echo ""
+echo "[Cleanup]"
+
+EXTRA_TAB=$("$IT2" tab list --json 2>&1 | python3 -c "
+import sys, json
+tabs = json.load(sys.stdin)
+win = '$NEW_WIN'
+wintabs = [t for t in tabs if t.get('window_id') == win]
+if len(wintabs) > 1:
+    print(wintabs[-1]['id'])
+else:
+    print('')
+")
+if [ -n "$EXTRA_TAB" ]; then
+  run_test "tab close" "$IT2" tab close "$EXTRA_TAB" --force
+fi
+
+run_test "window close" "$IT2" window close "$NEW_WIN" --force
+
+# ------------------------------------------------------------------
+# Summary
+# ------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "Failures:$FAILURES"
+  echo "=========================================="
+  exit 1
+else
+  echo "=========================================="
+  exit 0
+fi

--- a/tests/E2E.md
+++ b/tests/E2E.md
@@ -1,0 +1,140 @@
+# E2E Testing Guide
+
+This document describes how to run end-to-end tests for the `it2` CLI against a live iTerm2 instance.
+
+## Prerequisites
+
+- **macOS** with iTerm2 running
+- iTerm2's **Python API** enabled (Preferences → General → Magic → Enable Python API)
+- Python 3.10+ installed (tests should cover all versions in the CI matrix)
+
+## Unit Tests vs E2E Tests
+
+| | Unit tests (`pytest`) | E2E tests (`e2e-test.sh`) |
+|---|---|---|
+| **Runs in CI** | Yes | No (requires live iTerm2) |
+| **iTerm2 connection** | Mocked | Real |
+| **Side effects** | None | Creates/closes windows, tabs, sessions |
+| **Speed** | ~1 second | ~10 seconds per Python version |
+| **Purpose** | Logic correctness | Verify real iTerm2 API interaction |
+
+## Quick Start
+
+```bash
+# Run with the default it2 from PATH
+./scripts/e2e-test.sh
+
+# Run with a specific binary
+./scripts/e2e-test.sh /path/to/venv/bin/it2
+```
+
+## Testing Across Multiple Python Versions
+
+Use `uv` to create isolated venvs for each target version:
+
+```bash
+VERSIONS="3.10 3.11 3.12 3.13 3.14"
+
+for v in $VERSIONS; do
+  uv venv --python "$v" "/tmp/it2-test-$v"
+  uv pip install --python "/tmp/it2-test-$v/bin/python" -e ".[dev]"
+done
+
+for v in $VERSIONS; do
+  echo ""
+  echo "====== Python $v ======"
+  ./scripts/e2e-test.sh "/tmp/it2-test-$v/bin/it2"
+done
+
+# Cleanup
+for v in $VERSIONS; do
+  rm -rf "/tmp/it2-test-$v"
+done
+```
+
+## What the Script Tests
+
+The script creates a temporary window, runs every command group inside it, and tears it down at the end.
+
+### App commands
+- `app activate` — bring iTerm2 to front
+- `app version` — query iTerm2 version
+- `app theme` — get current theme
+- `app get-focus` — get focused window/tab/session
+
+### Window commands (side effects)
+- `window list` / `window list --json`
+- `window new` — creates a test window (cleaned up at the end)
+- `window move` — repositions the test window
+- `window resize` — resizes the test window
+- `window fullscreen toggle` — toggles fullscreen on then off
+- `window close --force` — closes the test window
+
+### Tab commands (side effects)
+- `tab list` / `tab list --json`
+- `tab new` — creates a tab in the test window
+- `tab next` / `tab prev` / `tab goto`
+- `tab close --force`
+
+### Session commands (side effects)
+- `session list` / `session list --json`
+- `session split` (horizontal) / `session split --vertical`
+- `session set-name` — renames a session
+- `session send` — sends text without newline
+- `session run` — sends text with newline (executes as command)
+- `session read` — reads screen contents
+- `session get-var` — reads a session variable
+- `session clear` — clears the screen
+
+### Profile commands
+- `profile list` / `profile show Default`
+- `profile apply` — applies a profile to a session
+
+### Broadcast commands
+- `app broadcast on` / `app broadcast off`
+
+### Shortcuts
+- `ls` (alias for `session list`)
+- `ls --json`
+
+### Config commands
+- `config-path` — shows config file path
+- `config-reload` — reloads config file
+
+## Known Behaviors
+
+### iTerm2 native "Close Window?" dialog
+
+When closing a window that contains sessions with active processes, iTerm2 may show a native macOS confirmation dialog:
+
+> Close Window #N?
+
+This is **not** a bug. The `--force` flag in `window close` and `tab close` skips the CLI-level confirmation (`click.confirm()`), but it does **not** suppress iTerm2's own native dialog. You need to click "OK" manually.
+
+This happens because the E2E test runs `session run "echo test"` which spawns a shell process. When the window is closed shortly after, iTerm2 detects the active process and asks for confirmation.
+
+**Workaround when running tests**: just press OK/Enter when the dialog appears.
+
+### Commands NOT tested by the script
+
+The following commands are intentionally excluded from automated E2E testing:
+
+| Command | Reason |
+|---|---|
+| `app quit` | Would terminate iTerm2 |
+| `app theme <value>` (set) | Changes user's theme preference |
+| `app broadcast add` | Requires specific session IDs setup |
+| `session close` | Tested implicitly via `window close` |
+| `session restart` | Restarts the shell process |
+| `session copy` | Depends on selection state |
+| `session capture` | Writes files to disk |
+| `session set-var` | May affect session behavior |
+| `profile set` | Modifies profile permanently |
+| `window arrange-*` | Modifies saved arrangements |
+| `monitor *` | Long-running / blocking commands |
+| `load` / `alias` | Requires config file setup |
+| Shortcuts: `new`, `newtab`, `send`, `run`, `split`, `vsplit`, `clear` | Covered by their non-shortcut equivalents |
+
+## Adding New Commands
+
+When adding a new command to `it2`, add a corresponding `run_test` call to `scripts/e2e-test.sh`. Place it in the appropriate section and ensure cleanup if the command creates resources.


### PR DESCRIPTION
## Summary

- Add `scripts/e2e-test.sh`: a shell script that runs 37 E2E tests against a live iTerm2 instance, covering all command groups including side-effect commands (window/tab/session creation, text sending, splitting, fullscreen, broadcast, profile apply, etc.) with automatic cleanup.
- Add `tests/E2E.md`: documentation covering prerequisites, usage, multi-Python-version testing workflow, known behaviors (e.g. native "Close Window?" dialog), and intentionally excluded commands with rationale.

Verified on Python 3.10, 3.11, 3.12, 3.13, and 3.14 — all 37 tests pass on each version.

## Test plan

- [ ] Run `./scripts/e2e-test.sh` on a machine with iTerm2 running and Python API enabled
- [ ] Verify all 37 tests pass and the test window is cleaned up
- [ ] Review `tests/E2E.md` for accuracy and completeness