### PR TITLE
Normalize iTerm2 session ID alias handling

### DIFF
--- a/src/it2/commands/app.py
+++ b/src/it2/commands/app.py
@@ -5,6 +5,7 @@ import iterm2
 
 from ..core.connection import run_command
 from ..core.errors import handle_error
+from ..core.session_handler import get_session_by_id
 
 # Theme value mapping for PreferenceKey.THEME
 _THEME_MAP = {
@@ -105,7 +106,7 @@ async def broadcast_add(
     # Verify all sessions exist
     sessions = []
     for sid in session_ids:
-        session = app.get_session_by_id(sid)
+        session = get_session_by_id(app, sid)
         if not session:
             handle_error(f"Session '{sid}' not found", 3)
         sessions.append(session)

--- a/src/it2/commands/profile.py
+++ b/src/it2/commands/profile.py
@@ -10,6 +10,7 @@ from rich.table import Table
 
 from ..core.connection import run_command
 from ..core.errors import handle_error
+from ..core.session_handler import get_session_by_id
 
 console = Console()
 
@@ -142,7 +143,7 @@ async def apply(
 
     # Get target session
     if session:
-        target_session = app.get_session_by_id(session)
+        target_session = get_session_by_id(app, session)
         if not target_session:
             handle_error(f"Session '{session}' not found", 3)
     else:

--- a/src/it2/commands/session.py
+++ b/src/it2/commands/session.py
@@ -9,7 +9,7 @@ from rich.table import Table
 
 from ..core.connection import run_command
 from ..core.errors import handle_error
-from ..core.session_handler import get_session_info, get_target_sessions
+from ..core.session_handler import get_session_by_id, get_session_info, get_target_sessions
 
 console = Console()
 
@@ -157,7 +157,7 @@ async def restart(session: str | None, connection: iterm2.Connection, app: iterm
 @run_command
 async def focus(session_id: str, connection: iterm2.Connection, app: iterm2.App) -> None:
     """Focus a specific session."""
-    target_session = app.get_session_by_id(session_id)
+    target_session = get_session_by_id(app, session_id)
     if not target_session:
         handle_error(f"Session '{session_id}' not found", 3)
 

--- a/src/it2/core/session_handler.py
+++ b/src/it2/core/session_handler.py
@@ -11,7 +11,17 @@ _TERMID_RE = re.compile(rf"^w\d+t\d+p\d+\.(?P<uuid>{_UUID_PATTERN})$")
 
 
 def normalize_session_id(session_id: str | None) -> str | None:
-    """Normalize session ID aliases to a canonical UUID when possible."""
+    """Normalize session ID aliases to a canonical UUID when possible.
+
+    Why this exists:
+      iTerm2 APIs like ``app.get_session_by_id`` expect a bare UUID, but users
+      and shell environments often provide aliases such as ``ITERM_SESSION_ID``
+      (``w0t0p0:UUID``) or termid-like values (``w0t0p0.UUID``).
+
+    When this is needed:
+      Use this before any session lookup that accepts user-provided IDs
+      (CLI arguments, environment-derived values, clipboard-pasted IDs).
+    """
     if session_id is None:
         return None
 
@@ -30,7 +40,11 @@ def normalize_session_id(session_id: str | None) -> str | None:
 
 
 def get_session_by_id(app: App, session_id: str | None) -> Session | None:
-    """Get session by ID, accepting UUID and iTerm session ID formats."""
+    """Get a session by ID while accepting common iTerm2 alias formats.
+
+    This centralizes lookup behavior so command handlers do not each need to
+    remember which ID shape is accepted by iTerm2's Python API.
+    """
     if session_id is None:
         return None
 

--- a/src/it2/core/session_handler.py
+++ b/src/it2/core/session_handler.py
@@ -6,6 +6,10 @@ import sys
 from iterm2 import App, Session
 
 _UUID_PATTERN = r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+# iTerm2 commonly exposes these aliases:
+# - ITERM_SESSION_ID / TERM_SESSION_ID: w<window>t<tab>p<pane>:<GUID>
+# - session.termid variable:            w<window>t<tab>p<pane>.<GUID>
+# Only the GUID portion is the canonical API session identifier.
 _ITERM_SESSION_ID_RE = re.compile(rf"^w\d+t\d+p\d+:(?P<uuid>{_UUID_PATTERN})$")
 _TERMID_RE = re.compile(rf"^w\d+t\d+p\d+\.(?P<uuid>{_UUID_PATTERN})$")
 
@@ -14,13 +18,17 @@ def normalize_session_id(session_id: str | None) -> str | None:
     """Normalize session ID aliases to a canonical UUID when possible.
 
     Why this exists:
-      iTerm2 APIs like ``app.get_session_by_id`` expect a bare UUID, but users
-      and shell environments often provide aliases such as ``ITERM_SESSION_ID``
-      (``w0t0p0:UUID``) or termid-like values (``w0t0p0.UUID``).
+      iTerm2 core builds ``ITERM_SESSION_ID`` in the form
+      ``w<window>t<tab>p<pane>:<guid>`` (see PTYSession.sessionId), and also
+      publishes ``session.termid`` as ``w<window>t<tab>p<pane>.<guid>``.
+      However, iTerm2's Python API stores ``Session.session_id`` as only the
+      GUID and ``App.get_session_by_id`` does an exact string match against that
+      GUID. Passing prefixed aliases directly therefore fails lookup.
 
     When this is needed:
-      Use this before any session lookup that accepts user-provided IDs
-      (CLI arguments, environment-derived values, clipboard-pasted IDs).
+      Any time we accept user-provided session identifiers (CLI args, env vars,
+      script output), because those inputs often come from shell integration
+      variables instead of the bare API GUID.
     """
     if session_id is None:
         return None
@@ -42,8 +50,8 @@ def normalize_session_id(session_id: str | None) -> str | None:
 def get_session_by_id(app: App, session_id: str | None) -> Session | None:
     """Get a session by ID while accepting common iTerm2 alias formats.
 
-    This centralizes lookup behavior so command handlers do not each need to
-    remember which ID shape is accepted by iTerm2's Python API.
+    This centralizes the ID-shape mismatch between shell-facing identifiers and
+    API-facing identifiers so command handlers can call one safe lookup path.
     """
     if session_id is None:
         return None

--- a/tests/test_session_commands.py
+++ b/tests/test_session_commands.py
@@ -483,7 +483,9 @@ def test_session_focus_iterm_session_id(
     )
     uuid = "93DC1CBF-8BA1-48B2-9C6A-834D3AECF340"
     iterm_session_id = f"w0t1p2:{uuid}"
-    mock_app.get_session_by_id = MagicMock(side_effect=lambda sid: mock_session if sid == uuid else None)
+    mock_app.get_session_by_id = MagicMock(
+        side_effect=lambda sid: mock_session if sid == uuid else None
+    )
 
     result = runner.invoke(cli, ["session", "focus", iterm_session_id])
     assert result.exit_code == 0

--- a/tests/test_session_commands.py
+++ b/tests/test_session_commands.py
@@ -462,6 +462,41 @@ def test_session_focus(
 @patch("iterm2.run_until_complete")
 @patch("os.environ.get")
 @patch("it2.core.connection._connection_manager")
+def test_session_focus_iterm_session_id(
+    mock_conn_mgr,
+    mock_env_get,
+    mock_run_until_complete,
+    mock_async_get_app,
+    mock_async_create,
+    runner,
+    mock_app,
+    mock_session,
+):
+    """Test session focus accepts ITERM_SESSION_ID format."""
+    setup_iterm2_mocks(
+        mock_conn_mgr,
+        mock_env_get,
+        mock_run_until_complete,
+        mock_async_get_app,
+        mock_async_create,
+        mock_app,
+    )
+    uuid = "93DC1CBF-8BA1-48B2-9C6A-834D3AECF340"
+    iterm_session_id = f"w0t1p2:{uuid}"
+    mock_app.get_session_by_id = MagicMock(side_effect=lambda sid: mock_session if sid == uuid else None)
+
+    result = runner.invoke(cli, ["session", "focus", iterm_session_id])
+    assert result.exit_code == 0
+    assert f"Focused session: {iterm_session_id}" in result.output
+    mock_app.get_session_by_id.assert_called_once_with(uuid)
+    mock_session.async_activate.assert_called_once()
+
+
+@patch("iterm2.Connection.async_create")
+@patch("iterm2.async_get_app")
+@patch("iterm2.run_until_complete")
+@patch("os.environ.get")
+@patch("it2.core.connection._connection_manager")
 def test_session_clear(
     mock_conn_mgr,
     mock_env_get,


### PR DESCRIPTION
## Summary
Normalize iTerm2 session ID aliases before session lookup so CLI commands accept both shell-facing IDs and canonical API IDs.

## Changes
- Add `normalize_session_id` in `src/it2/core/session_handler.py` to convert `w<window>t<tab>p<pane>:<GUID>` and `w<window>t<tab>p<pane>.<GUID>` into canonical GUIDs.
- Add `get_session_by_id` helper in `src/it2/core/session_handler.py` and route session resolution through this helper.
- Update `session focus` in `src/it2/commands/session.py` to use normalized lookup.
- Update `profile apply` in `src/it2/commands/profile.py` to use normalized lookup.
- Update `app broadcast add` in `src/it2/commands/app.py` to use normalized lookup.
- Add/extend tests in `tests/test_session_handler.py`, `tests/test_session_commands.py`, `tests/test_profile_commands.py`, and `tests/test_app_commands.py` to cover alias formats.
- Add detailed helper comments/docstrings with iTerm2 implementation context (shell/env alias format vs API exact-match behavior).

## Why
iTerm2 often exposes session IDs via shell integration values (e.g. `ITERM_SESSION_ID` and `session.termid`) that include window/tab/pane prefixes. The Python API lookup uses exact `Session.session_id` GUID matching, so alias IDs can fail even when the session exists.

## Notes
- Special selectors `active` and `all` remain unchanged.
- A fallback lookup with the original input is kept to reduce risk if iTerm2 introduces additional ID shapes.
- CI formatting failure was addressed by applying `black` formatting to `tests/test_session_commands.py`.

## Testing
- `uv run --with ruff ruff check src tests`
- `uv run --with mypy --with types-PyYAML mypy src`
- `uv run --with black black --check .`
- `uv run --with pytest-asyncio pytest -q tests/test_session_handler.py tests/test_session_commands.py tests/test_profile_commands.py tests/test_app_commands.py`
- GitHub Actions run passed: https://github.com/mkusaka/it2/actions/runs/21803781233
