### PR TITLE
Update uvx to uv in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ A powerful command-line interface for controlling iTerm2 using its Python API.
 pip install it2
 ```
 
-### Using uvx (recommended)
+### Using uv (recommended)
 
 ```bash
-uvx it2
+uv tool install it2
 ```
 
 ## Quick Start


### PR DESCRIPTION
If my understanding is correct, `uvx` is for a one time execution, but `uv tool install it2` installed it2 on my system globally