### PR TITLE
Replace null bytes with spaces in session read output

### DIFF
--- a/src/it2/commands/session.py
+++ b/src/it2/commands/session.py
@@ -180,7 +180,8 @@ async def read(
     contents = await target_session.async_get_screen_contents()
 
     # Extract lines from ScreenContents using line(i).string
-    text_lines = [contents.line(i).string for i in range(contents.number_of_lines)]
+    # Null bytes signify a screen location where a character hasn't been set. Visually they appear blank.
+    text_lines = [contents.line(i).string.replace('\0', ' ') for i in range(contents.number_of_lines)]
 
     if lines is not None:
         # Get last N lines


### PR DESCRIPTION
Terminal cells that have never been written to are represented as `\0` in the string returned by `async_get_screen_contents()` (see [[ScreenChar.h](https://github.com/gnachman/iTerm2/blob/9d71745f738f0e44b14160ae2ad08ea3fc441889/sources/ScreenChar.h#L254)](https://github.com/gnachman/iTerm2/blob/9d71745f738f0e44b14160ae2ad08ea3fc441889/sources/ScreenChar.h#L254)). iTerm2 paints them as blank, but consumers that strip or normalize control characters collapse words together.

Before:
<img width="1512" height="272" alt="image" src="https://github.com/user-attachments/assets/a5748925-1b81-469b-bd91-9a75dc4373da" />


After:
<img width="1512" height="299" alt="image" src="https://github.com/user-attachments/assets/8435229a-d99c-4880-a059-99909f23b2e4" />